### PR TITLE
fix: new hecoscan

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 ### HecoSwap
 ```
-factory  : https://scan.hecochain.com/address/0xb0b670fc1F7724119963018DB0BfA86aDb22d941
-router   : https://scan.hecochain.com/address/0xED7d5F38C79115ca12fe6C0041abb22F0A06C300
+factory  : https://hecoinfo.com/address/0xb0b670fc1F7724119963018DB0BfA86aDb22d941#code
+router   : https://hecoinfo.com/address/0xED7d5F38C79115ca12fe6C0041abb22F0A06C300#code
 initcode : 0x2ad889f82040abccb2649ea6a874796c1601fb67f91a747a80e08860c73ddf24
-MDXToken : https://scan.hecochain.com/address/0x25D2e80cB6B86881Fd7e07dd263Fb79f4AbE033c
-HecoPool : https://scan.hecochain.com/address/0xFB03e11D93632D97a8981158A632Dd5986F5E909
-swapMining : https://scan.hecochain.com/address/0x7373c42502874C88954bDd6D50b53061F018422e
-teamTimeLock : https://scan.hecochain.com/address/0xa3FD9758323C8A86292B55702F631c81283c9B79
-InvestorsTimeLock : https://scan.hecochain.com/address/0xa6FE654241140469d1757A5bB8Ee844325059569
-brandTimeLock : https://scan.hecochain.com/address/0x465D246233Ba20e7cfc95743B5d073BE8A7746B0
-Airdrop  : https://scan.hecochain.com/address/0x9197d717a4F45B672aCacaB4CC0C6e09222f8695
-Repurchase : https://scan.hecochain.com/address/0x46900C0c18ace98bAAB81561B9906Dc93287910C
-BlackHole : https://scan.hecochain.com/address/0xF9852C6588b70ad3c26daE47120f174527e03a25
+MDXToken : https://hecoinfo.com/address/0x25D2e80cB6B86881Fd7e07dd263Fb79f4AbE033c#code
+HecoPool : https://hecoinfo.com/address/0xFB03e11D93632D97a8981158A632Dd5986F5E909#code
+swapMining : https://hecoinfo.com/address/0x7373c42502874C88954bDd6D50b53061F018422e#code
+teamTimeLock : https://hecoinfo.com/address/0xa3FD9758323C8A86292B55702F631c81283c9B79#code
+InvestorsTimeLock : https://hecoinfo.com/address/0xa6FE654241140469d1757A5bB8Ee844325059569#code
+brandTimeLock : https://hecoinfo.com/address/0x465D246233Ba20e7cfc95743B5d073BE8A7746B0#code
+Airdrop  : https://hecoinfo.com/address/0x9197d717a4F45B672aCacaB4CC0C6e09222f8695#code
+Repurchase : https://hecoinfo.com/address/0x46900C0c18ace98bAAB81561B9906Dc93287910C#code
+BlackHole : https://hecoinfo.com/address/0xF9852C6588b70ad3c26daE47120f174527e03a25#code
 ```
 ## QuickStart
 


### PR DESCRIPTION
old version is old.
also, links directly to the code (optional, but useful, imho)